### PR TITLE
Add searchbar and toggle buttons for filtering table rows

### DIFF
--- a/src/components/FilterOptions.tsx
+++ b/src/components/FilterOptions.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import * as Types from "../utils/Types";
+import {
+  handleInputClear,
+  handleInputText,
+  handleVisibilityToggle,
+} from "../utils/EventHandlers";
+
+const FilterOptions = (props: Types.FilterOptionsProps) => {
+  const [state] = props.stateManager;
+  return (
+    <div className="filter-options">
+      <form className="search">
+        <input
+          type="text"
+          placeholder="Enter institution, lab, or address"
+          onChange={handleInputText(props.stateManager)}
+          value={state.searchBarContent}
+        />
+        <input
+          type="button"
+          onClick={handleInputClear(props.stateManager)}
+          value="Clear"
+        />
+      </form>
+      <form className="visibility">
+        <input
+          type="checkbox"
+          onClick={handleVisibilityToggle(props.stateManager)}
+          checked={state.useMarkerVisibility}
+        />
+        <label>Filter table by visibility</label>
+      </form>
+    </div>
+  );
+};
+
+export default FilterOptions;

--- a/src/components/MapChart.tsx
+++ b/src/components/MapChart.tsx
@@ -11,7 +11,11 @@ const MapChart = (props: Types.MapChartProps): JSX.Element => {
   return (
     <div className="mapchart">
       <ZoomControls stateManager={props.stateManager} />
-      <ComposableMap id="container" projectionConfig={{ scale: 200 }}>
+      <ComposableMap
+        id={Config.mapContainerName}
+        height={550}
+        projectionConfig={{ scale: 200 }}
+      >
         <ZoomableGroup
           zoom={state.mousePosition.zoom}
           center={state.mousePosition.coordinates}

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -6,6 +6,7 @@ import {
   createWaypointsTableBody,
   createWaypointDetails,
 } from "../utils/Renderers";
+import FilterOptions from "./FilterOptions";
 
 const SideBar = (props: Types.SideBarProps): JSX.Element => {
   return (
@@ -17,6 +18,7 @@ const SideBar = (props: Types.SideBarProps): JSX.Element => {
           {createWaypointsTableBody(props.stateManager, Config.tableHeaderKeys)}
         </table>
       </div>
+      <FilterOptions stateManager={props.stateManager} />
       <h1>Selected waypoint details</h1>
       <div className="tableFixHead waypoint-details">
         <table>{createWaypointDetails(props.stateManager)}</table>

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  overflow-y: hidden;
+  background: #eee;
 }
 
 code {
@@ -42,11 +42,12 @@ svg {
   line-height: 1.1;
   margin: 0.67em 0;
   box-sizing: border-box;
-  padding-left: 20px;
+  margin-left: 20px;
 }
 
 .mapchart {
   width: 70%;
+  background: #fff;
 }
 
 .controls-wrapper {
@@ -76,7 +77,7 @@ svg {
 
 .tableFixHead {
   overflow-y: auto;
-  height: 20em;
+  max-height: 18em;
 }
 .waypoints thead th {
   position: sticky;
@@ -92,7 +93,7 @@ td {
   padding: 8px 16px;
 }
 .tableFixHead:first-of-type {
-  margin-bottom: 2em;
+  margin-bottom: 0.67em;
 }
 
 /* The thick country border that gets displayed when clicking on a country is 
@@ -108,4 +109,43 @@ outline-width property still works! How confusing. */
   /* outline-color: -webkit-focus-ring-color; */
   /* outline-style: auto; */
   outline-width: 0px;
+}
+
+.filter-options {
+  float: left;
+  margin-bottom: 1em;
+  margin-left: 20px;
+}
+
+.search {
+  float: left;
+}
+
+.search input[type="text"] {
+  border: none;
+  float: left;
+  font-size: 17px;
+  margin-top: 8px;
+  min-width: 250px;
+  padding: 6px;
+}
+
+.search input[type="button"] {
+  border: none;
+  cursor: pointer;
+  background: #ddd;
+  float: left;
+  font-size: 17px;
+  margin-top: 8px;
+  margin-right: 8px;
+  padding: 6px;
+}
+
+.search button:hover {
+  background: #ccc;
+}
+
+.visibility {
+  float: left;
+  margin-top: 8px;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,8 +31,9 @@ const App = (): JSX.Element => {
       type: "updateCombinedRows",
       value: getUpdatedCombinedRowsByZoom(rows, combinedRows, zoom),
     });
-    console.log("combinedRows", combinedRows);
   }, [dispatch, rows, combinedRows, zoom, coordinates]);
+
+  console.log("state.tooltipContent", state.tooltipContent);
 
   return (
     <div id="wrapper">

--- a/src/utils/Config.tsx
+++ b/src/utils/Config.tsx
@@ -51,12 +51,17 @@ export const defaultMousePosition: Types.position = {
   coordinates: defaultCoordinates,
   zoom: minZoom,
 };
+export const defaultSearchBarContent: string = "";
+export const defaultToggle: boolean = false;
 export const defaultState: Types.state = {
   rows: defaultRows,
   combinedRows: defaultCombinedRows,
   tooltipContent: defaultTooltipContent,
   currentCombinedRow: defaultCombinedRow,
   mousePosition: defaultMousePosition,
+  searchBarContent: defaultSearchBarContent,
+  useMarkerVisibility: defaultToggle,
+  useSearchBar: defaultToggle,
 };
 
 /**
@@ -100,3 +105,4 @@ export const tableHeaderKeys = ["institution", "lab", "address"];
 export const elementIds: Types.componentToId = {
   Marker: (index: number) => `marker-${index}`,
 };
+export const mapContainerName = "container";

--- a/src/utils/EventHandlers.tsx
+++ b/src/utils/EventHandlers.tsx
@@ -79,3 +79,33 @@ export const handleMarkerOnClick = (
 ) => (): void => {
   dispatch({ type: "setCurrentCombinedRow", value: givenRow });
 };
+
+//////////////////////
+// FilterOptions.tsx
+//////////////////////
+
+export const handleVisibilityToggle = (
+  stateManager: Types.stateManager
+) => (): void => {
+  const [state, dispatch] = stateManager;
+  dispatch({ type: "toggleVisibility", value: !state.useMarkerVisibility });
+};
+
+export const handleInputText = (stateManager: Types.stateManager) => (
+  event: React.ChangeEvent<HTMLInputElement>
+): void => {
+  const [, dispatch] = stateManager;
+  dispatch({ type: "toggleSearchBarQuery", value: true });
+  dispatch({ type: "setSearchBarContent", value: event.target.value });
+};
+
+export const handleInputClear = (
+  stateManager: Types.stateManager
+) => (): void => {
+  const [, dispatch] = stateManager;
+  dispatch({ type: "toggleSearchBarQuery", value: false });
+  dispatch({
+    type: "setSearchBarContent",
+    value: Config.defaultSearchBarContent,
+  });
+};

--- a/src/utils/StateUpdaters.tsx
+++ b/src/utils/StateUpdaters.tsx
@@ -34,6 +34,12 @@ export const reducer = (
         currentCombinedRow: Config.defaultCombinedRow,
         mousePosition: action.value as Types.position,
       };
+    case "setSearchBarContent":
+      return { ...state, searchBarContent: action.value as string };
+    case "toggleVisibility":
+      return { ...state, useMarkerVisibility: action.value as boolean };
+    case "toggleSearchBarQuery":
+      return { ...state, useSearchBar: action.value as boolean };
     default:
       return state;
   }
@@ -170,7 +176,7 @@ export const getMarkerId = (index: number): string => {
 
 const elementIsInViewport = (element: HTMLElement | null): Types.Visibility => {
   const rectangle = element?.getBoundingClientRect();
-  const container = document.getElementById("container");
+  const container = document.getElementById(Config.mapContainerName);
   const elementNotValid = !element || 1 !== element.nodeType;
   if (elementNotValid || !rectangle || !container) {
     return undefined;

--- a/src/utils/Types.tsx
+++ b/src/utils/Types.tsx
@@ -11,7 +11,8 @@ export type StateProp =
   | string
   | combinedRow
   | position
-  | number;
+  | number
+  | boolean;
 
 export interface row {
   institution: string;
@@ -39,6 +40,10 @@ export interface position {
 }
 
 export interface SideBarProps {
+  stateManager: stateManager;
+}
+
+export interface FilterOptionsProps {
   stateManager: stateManager;
 }
 
@@ -84,6 +89,9 @@ export interface state {
   tooltipContent: string;
   currentCombinedRow: combinedRow;
   mousePosition: position;
+  searchBarContent: string;
+  useMarkerVisibility: boolean;
+  useSearchBar: boolean;
 }
 
 export interface action {


### PR DESCRIPTION
To resolve [7846](https://github.com/cBioPortal/cbioportal/issues/7846) for feature 2.

### Changes made:
- Added searchbar underneath table of all institution/lab/address rows
- Added buttons to toggle whether table rows should be filtered by search query, [visible markers](https://github.com/jtquach1/installation-map/pull/3), or neither
- Modified styles for tables and page document
- Merged changes with filter_table_visible_markers so visibility toggle works

### Bugs
- From [filter_table_visible_markers](https://github.com/jtquach1/installation-map/pull/3): surrounding markers inside/outside the map container being considered "visible".

### Before:  
![table_searchbar_before](https://user-images.githubusercontent.com/33106214/91889483-e0727d00-ec5b-11ea-9afa-d4f4585d3e0f.png)

### After:
#### Search by institution, lab, or address 
![search_institution_lab_address](https://user-images.githubusercontent.com/33106214/91915369-5b518d00-ec88-11ea-876c-dff56d4d2993.gif)

#### Toggle visibility and search on/off, cancelling one another if trying to toggle both on
![search_and_visibility](https://user-images.githubusercontent.com/33106214/91915372-5ee51400-ec88-11ea-8387-7e5526bf9adb.gif)