### PR TITLE
Trigger table scroll to corresponding row when marker is clicked

### DIFF
--- a/src/components/OrphanTableRows.tsx
+++ b/src/components/OrphanTableRows.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as Types from "./../utils/Types";
 import { getTableRowColor } from "../utils/Renderers";
 import { handleMarkerOnClick } from "../utils/EventHandlers";
+import { getMarkerIdentifier } from "../utils/StateUpdaters";
 
 const OrphanTableRows = (props: Types.OrphanTableRowsProps): JSX.Element => {
   const [state, dispatch] = props.stateManager;
@@ -11,6 +12,7 @@ const OrphanTableRows = (props: Types.OrphanTableRowsProps): JSX.Element => {
     state.currentCombinedRow,
     props.givenIndex
   );
+  const markerIdentifier = getMarkerIdentifier(props.givenCombinedRow.index);
 
   /* React.Fragment allows for the return of orphan sibling elements without 
   adding an extra parent element to the DOM. The table rows need to be orphans 
@@ -22,6 +24,7 @@ const OrphanTableRows = (props: Types.OrphanTableRowsProps): JSX.Element => {
           key={row.index}
           onClick={handleMarkerOnClick(dispatch, props.givenCombinedRow)}
           style={{ background: combinedRowColor }}
+          className={markerIdentifier}
         >
           {props.keys.map((key, index) => {
             const keyIsValid = key in row;

--- a/src/components/RowMarker.tsx
+++ b/src/components/RowMarker.tsx
@@ -12,7 +12,7 @@ import {
   handleMarkerOnClick,
   handleMarkerOnMouse,
 } from "../utils/EventHandlers";
-import { getMarkerId } from "../utils/StateUpdaters";
+import { getMarkerIdentifier } from "../utils/StateUpdaters";
 import * as Types from "../utils/Types";
 
 const RowMarker = (props: Types.RowMarkerProps): JSX.Element => {
@@ -31,7 +31,7 @@ const RowMarker = (props: Types.RowMarkerProps): JSX.Element => {
       coordinates={givenRow.averageCoordinates}
       onMouseEnter={handleMarkerOnMouse(dispatch, combinedName)}
       onMouseLeave={handleMarkerOnMouse(dispatch)}
-      id={getMarkerId(givenRow.index)}
+      id={getMarkerIdentifier(givenRow.index)}
     >
       <PlaceIcon transform={mapMarkerTransform} markerColor={mapMarkerColor} />
       {zoomedInEnoughToDisplay && createMarkerText(combinedName, currentZoom)}

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -11,7 +11,7 @@ const SideBar = (props: Types.SideBarProps): JSX.Element => {
   return (
     <div className="left">
       <h1>Waypoints</h1>
-      <div className="tableFixHead waypoints">
+      <div className="tableFixHead" id="waypoints">
         <table>
           {createWaypointsTableHead(Config.tableHeaderKeys)}
           {createWaypointsTableBody(props.stateManager, Config.tableHeaderKeys)}

--- a/src/index.css
+++ b/src/index.css
@@ -78,7 +78,7 @@ svg {
   overflow-y: auto;
   height: 20em;
 }
-.waypoints thead th {
+#waypoints thead th {
   position: sticky;
   top: 0;
 }

--- a/src/utils/Config.tsx
+++ b/src/utils/Config.tsx
@@ -97,6 +97,6 @@ export const markerDetailMap: Types.markerDetail[] = [
 export const tableHeaderKeys = ["institution", "lab", "address"];
 
 // Configuration for certain React components to be passed a particular id.
-export const elementIds: Types.componentToId = {
+export const componentIds: Types.componentToIdentifier = {
   Marker: (index: number) => `marker-${index}`,
 };

--- a/src/utils/EventHandlers.tsx
+++ b/src/utils/EventHandlers.tsx
@@ -1,5 +1,6 @@
 import * as Config from "./Config";
 import * as Types from "./Types";
+import { getMarkerIdentifier } from "./StateUpdaters";
 
 /////////////////
 // MapChart.tsx
@@ -78,4 +79,28 @@ export const handleMarkerOnClick = (
   givenRow: Types.combinedRow
 ) => (): void => {
   dispatch({ type: "setCurrentCombinedRow", value: givenRow });
+  handleWaypointsTableScrollbar(givenRow.index);
+};
+
+const handleWaypointsTableScrollbar = (rowIndex: number): void => {
+  const waypointsTable = document.getElementById("waypoints");
+  const firstRowOffset = getFirstRowOffset(rowIndex);
+  const tableHeadHeight = getTableHeadHeight();
+  if (!waypointsTable || !firstRowOffset || !tableHeadHeight) {
+  } else {
+    const newVerticalScrollPosition = firstRowOffset - tableHeadHeight;
+    waypointsTable.scrollTo(0, newVerticalScrollPosition);
+  }
+};
+
+const getTableHeadHeight = (): number | undefined => {
+  const waypointsTableHead = document.getElementById("waypoints-head");
+  return waypointsTableHead?.offsetHeight;
+};
+
+const getFirstRowOffset = (rowIndex: number): number | undefined => {
+  const markerIdentifier = getMarkerIdentifier(rowIndex);
+  const tableRows = document.getElementsByClassName(markerIdentifier);
+  const firstTableRow = tableRows[0] as HTMLElement | undefined;
+  return !firstTableRow ? undefined : firstTableRow.offsetTop;
 };

--- a/src/utils/Renderers.tsx
+++ b/src/utils/Renderers.tsx
@@ -174,7 +174,7 @@ export const createMarkerText = (
 
 export const createWaypointsTableHead = (keys: string[]): JSX.Element => {
   return (
-    <thead>
+    <thead id="waypoints-head">
       <tr>
         {keys.map((key: string, index: number) => (
           <th key={index} style={{ background: Config.tableHeaderColor }}>

--- a/src/utils/StateUpdaters.tsx
+++ b/src/utils/StateUpdaters.tsx
@@ -158,14 +158,14 @@ const createCombinedRow = (
 };
 
 const getCombinedRowVisibility = (index: number): Types.Visibility => {
-  const elementId = getMarkerId(index);
+  const elementId = getMarkerIdentifier(index);
   const svgMarker = document.getElementById(elementId);
   const isMarkerVisible = elementIsInViewport(svgMarker);
   return isMarkerVisible;
 };
 
-export const getMarkerId = (index: number): string => {
-  return Config.elementIds.Marker(index);
+export const getMarkerIdentifier = (index: number): string => {
+  return Config.componentIds.Marker(index);
 };
 
 const elementIsInViewport = (element: HTMLElement | null): Types.Visibility => {

--- a/src/utils/Types.tsx
+++ b/src/utils/Types.tsx
@@ -102,6 +102,6 @@ export interface markerDetail {
   getRowPropContent: (value: any) => string;
 }
 
-export interface componentToId {
+export interface componentToIdentifier {
   [key: string]: (input: any) => string;
 }


### PR DESCRIPTION
To resolve [#7846](https://github.com/cBioPortal/cbioportal/issues/7846) for feature 3.

### Changes made:
- Clicking on a map marker triggers the waypoints table to scroll to the top of its corresponding table row
  - For a marker that doesn't exist in the waypoints table, the table does not scroll anywhere
  - Clicking on a table row has the same effect as clicking on its marker
-  Renamed variables and functions

### Before:
![before_table_scroll](https://user-images.githubusercontent.com/33106214/92045602-02006100-ed4f-11ea-96d8-7a89995c36ff.gif)

### After:
![after_table_scroll](https://user-images.githubusercontent.com/33106214/92045608-0593e800-ed4f-11ea-9b82-540ed7a35618.gif)