### PR TITLE
Use url params to render tiny/full versions of installation map

### DIFF
--- a/src/components/FilterOptions.tsx
+++ b/src/components/FilterOptions.tsx
@@ -1,10 +1,6 @@
 import React from "react";
+import * as EventHandlers from "../utils/EventHandlers";
 import * as Types from "../utils/Types";
-import {
-  handleInputClear,
-  handleInputText,
-  handleVisibilityToggle,
-} from "../utils/EventHandlers";
 
 const FilterOptions = (props: Types.FilterOptionsProps) => {
   const [state] = props.stateManager;
@@ -14,19 +10,19 @@ const FilterOptions = (props: Types.FilterOptionsProps) => {
         <input
           type="text"
           placeholder="Enter institution, lab, or address"
-          onChange={handleInputText(props.stateManager)}
+          onChange={EventHandlers.handleInputText(props.stateManager)}
           value={state.searchBarContent}
         />
         <input
           type="button"
-          onClick={handleInputClear(props.stateManager)}
+          onClick={EventHandlers.handleInputClear(props.stateManager)}
           value="Clear"
         />
       </form>
       <form className="visibility">
         <input
           type="checkbox"
-          onClick={handleVisibilityToggle(props.stateManager)}
+          onClick={EventHandlers.handleVisibilityToggle(props.stateManager)}
           checked={state.useMarkerVisibility}
         />
         <label>Filter table by visibility</label>

--- a/src/components/MapChart.tsx
+++ b/src/components/MapChart.tsx
@@ -1,34 +1,59 @@
 import React from "react";
 import ZoomControls from "../components/ZoomControls";
 import { ComposableMap, ZoomableGroup } from "react-simple-maps";
-import { handleMoveEnd } from "../utils/EventHandlers";
-import { createGeographies, createRowMarkers } from "../utils/Renderers";
 import * as Config from "../utils/Config";
+import * as EventHandlers from "../utils/EventHandlers";
+import * as Renderers from "../utils/Renderers";
 import * as Types from "../utils/Types";
 
 const MapChart = (props: Types.MapChartProps): JSX.Element => {
   const [state] = props.stateManager;
-  return (
-    <div className="mapchart">
-      <ZoomControls stateManager={props.stateManager} />
-      <ComposableMap
-        id={Config.mapContainerName}
-        height={550}
-        projectionConfig={{ scale: 200 }}
-      >
-        <ZoomableGroup
-          zoom={state.mousePosition.zoom}
-          center={state.mousePosition.coordinates}
-          onMoveEnd={handleMoveEnd(props.stateManager)}
-          minZoom={Config.minZoom}
-          maxZoom={Config.maxZoom}
+  const dimensions = Renderers.handleDimensions(state.inFullMode);
+
+  const fullModeRender = (): JSX.Element => {
+    return (
+      <div className="mapchart" style={{ width: props.width }}>
+        <ZoomControls stateManager={props.stateManager} />
+        <ComposableMap
+          id={Config.mapContainerName}
+          width={dimensions.width}
+          height={dimensions.height}
+          projection="geoEqualEarth"
+          projectionConfig={{ scale: dimensions.scale }}
         >
-          {createGeographies(props.stateManager)}
-          {createRowMarkers(props.stateManager)}
-        </ZoomableGroup>
-      </ComposableMap>
-    </div>
-  );
+          <ZoomableGroup
+            zoom={state.mousePosition.zoom}
+            center={state.mousePosition.coordinates}
+            onMoveEnd={EventHandlers.handleMoveEnd(props.stateManager)}
+            minZoom={Config.minZoom}
+            maxZoom={Config.maxZoom}
+          >
+            {Renderers.createGeographies(props.stateManager)}
+            {Renderers.createRowMarkers(props.stateManager)}
+          </ZoomableGroup>
+        </ComposableMap>
+      </div>
+    );
+  };
+
+  const smallModeRender = (): JSX.Element => {
+    return (
+      <div className="mapchart" style={{ width: props.width }}>
+        <ComposableMap
+          id={Config.mapContainerName}
+          width={dimensions.width}
+          height={dimensions.height}
+          projection="geoMercator"
+          projectionConfig={{ scale: dimensions.scale }}
+        >
+          {Renderers.createGeographies(props.stateManager)}
+          {Renderers.createRowMarkers(props.stateManager)}
+        </ComposableMap>
+      </div>
+    );
+  };
+
+  return state.inFullMode ? fullModeRender() : smallModeRender();
 };
 
 export default MapChart;

--- a/src/components/OrphanTableRows.tsx
+++ b/src/components/OrphanTableRows.tsx
@@ -1,18 +1,20 @@
 import React from "react";
 import * as Types from "./../utils/Types";
-import { getTableRowColor } from "../utils/Renderers";
-import { handleMarkerOnClick } from "../utils/EventHandlers";
-import { getMarkerIdentifier } from "../utils/StateUpdaters";
+import * as Renderers from "../utils/Renderers";
+import * as EventHandlers from "../utils/EventHandlers";
+import * as StateUpdaters from "../utils/StateUpdaters";
 
 const OrphanTableRows = (props: Types.OrphanTableRowsProps): JSX.Element => {
   const [state, dispatch] = props.stateManager;
   const rows = props.givenCombinedRow.rows;
-  const combinedRowColor = getTableRowColor(
+  const combinedRowColor = Renderers.getTableRowColor(
     props.givenCombinedRow,
     state.currentCombinedRow,
     props.givenIndex
   );
-  const markerIdentifier = getMarkerIdentifier(props.givenCombinedRow.index);
+  const markerIdentifier = StateUpdaters.getMarkerIdentifier(
+    props.givenCombinedRow.index
+  );
 
   /* React.Fragment allows for the return of orphan sibling elements without 
   adding an extra parent element to the DOM. The table rows need to be orphans 
@@ -22,7 +24,10 @@ const OrphanTableRows = (props: Types.OrphanTableRowsProps): JSX.Element => {
       {rows.map((row) => (
         <tr
           key={row.index}
-          onClick={handleMarkerOnClick(dispatch, props.givenCombinedRow)}
+          onClick={EventHandlers.handleMarkerOnClick(
+            dispatch,
+            props.givenCombinedRow
+          )}
           style={{ background: combinedRowColor }}
           className={markerIdentifier}
         >

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -10,7 +10,7 @@ import FilterOptions from "./FilterOptions";
 
 const SideBar = (props: Types.SideBarProps): JSX.Element => {
   return (
-    <div className="left">
+    <div className="left" style={{ width: props.width }}>
       <h1>Waypoints</h1>
       <div className="tableFixHead" id="waypoints">
         <table>

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,6 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: #eee;
 }
 
 code {
@@ -31,7 +30,6 @@ svg {
 .left {
   background-color: #f9f9f9;
   align-self: stretch;
-  width: 30%;
 }
 
 .left h1 {
@@ -46,7 +44,6 @@ svg {
 }
 
 .mapchart {
-  width: 70%;
   background: #fff;
 }
 

--- a/src/utils/Config.tsx
+++ b/src/utils/Config.tsx
@@ -21,6 +21,9 @@ export const minZoom = 1;
 export const oddRowColor = "#f6f6f6";
 export const tableHeaderColor = "#dcdcdc";
 export const zoomMultiplier = 2;
+export const urlQuery: RegExp = /\?/i;
+export const fullWidth = "unset";
+export const smallWidth = "342px";
 
 /**
  * World map JSON Url:
@@ -62,6 +65,7 @@ export const defaultState: Types.state = {
   searchBarContent: defaultSearchBarContent,
   useMarkerVisibility: defaultToggle,
   useSearchBar: defaultToggle,
+  inFullMode: defaultToggle,
 };
 
 /**
@@ -106,3 +110,16 @@ export const componentIds: Types.componentToIdentifier = {
   Marker: (index: number) => `marker-${index}`,
 };
 export const mapContainerName = "container";
+
+// Configuration for rendering MapChart.
+export const fullModeDimensions = {
+  width: 800,
+  height: 550,
+  scale: 200,
+};
+
+export const smallModeDimensions = {
+  width: 600,
+  height: 400,
+  scale: 100,
+};

--- a/src/utils/EventHandlers.tsx
+++ b/src/utils/EventHandlers.tsx
@@ -1,6 +1,6 @@
 import * as Config from "./Config";
 import * as Types from "./Types";
-import { getMarkerIdentifier } from "./StateUpdaters";
+import * as StateUpdaters from "./StateUpdaters";
 
 /////////////////
 // MapChart.tsx
@@ -99,7 +99,7 @@ const getTableHeadHeight = (): number | undefined => {
 };
 
 const getFirstRowOffset = (rowIndex: number): number | undefined => {
-  const markerIdentifier = getMarkerIdentifier(rowIndex);
+  const markerIdentifier = StateUpdaters.getMarkerIdentifier(rowIndex);
   const tableRows = document.getElementsByClassName(markerIdentifier);
   const firstTableRow = tableRows[0] as HTMLElement | undefined;
   return !firstTableRow ? undefined : firstTableRow.offsetTop;

--- a/src/utils/Renderers.tsx
+++ b/src/utils/Renderers.tsx
@@ -10,6 +10,10 @@ import * as Types from "./Types";
 // MapChart.tsx
 /////////////////
 
+export const handleDimensions = (inFullMode: boolean): Types.Dimensions => {
+  return inFullMode ? Config.fullModeDimensions : Config.smallModeDimensions;
+};
+
 export const createGeographies = (
   stateManager: Types.stateManager
 ): JSX.Element => {
@@ -299,4 +303,15 @@ export const getTableRowColor = (
 export const getDefaultRowColor = (rowIndex: number): string => {
   const rowIsEven = rowIndex % 2 === 0;
   return rowIsEven ? Config.evenRowColor : Config.oddRowColor;
+};
+
+//////////////
+// index.tsx
+//////////////
+
+export const setRootElementWidth = (value: string) => {
+  const rootElement = document.getElementById("root");
+  if (!!rootElement) {
+    rootElement.style.width = value;
+  }
 };

--- a/src/utils/StateUpdaters.tsx
+++ b/src/utils/StateUpdaters.tsx
@@ -40,6 +40,8 @@ export const reducer = (
       return { ...state, useMarkerVisibility: action.value as boolean };
     case "toggleSearchBarQuery":
       return { ...state, useSearchBar: action.value as boolean };
+    case "setInFullMode":
+      return { ...state, inFullMode: action.value as boolean };
     default:
       return state;
   }
@@ -187,4 +189,23 @@ const elementIsInViewport = (element: HTMLElement | null): Types.Visibility => {
     const withinHorizontalBounds = right >= 0 && left < clientWidth;
     return withinVerticalBounds && withinHorizontalBounds;
   }
+};
+
+export const checkInFullMode = (): boolean => {
+  const parameters = getWindowUrlParameters();
+  return !parameters.small;
+};
+
+const getWindowUrlParameters = (): Types.Parameters => {
+  const windowUrl = window.location.href;
+  const queryLocation = windowUrl.search(Config.urlQuery) + 1;
+  const query = windowUrl.slice(queryLocation);
+  const parameters = query
+    .split("&")
+    .map((assignment) => assignment.split("="))
+    .reduce((variable, value) => {
+      variable[value[0]] = value[1];
+      return variable;
+    }, {} as any);
+  return parameters;
 };

--- a/src/utils/Types.tsx
+++ b/src/utils/Types.tsx
@@ -5,6 +5,14 @@ export type CombinedProp = Point | row[] | number | Visibility;
 export type Dispatch = React.Dispatch<action>;
 export type ZoomHandler = (zoom: number) => void;
 export type Visibility = boolean | undefined;
+export type Parameters = {
+  [key: string]: string | undefined;
+};
+export type Dimensions = {
+  width: number;
+  height: number;
+  scale: number;
+};
 export type StateProp =
   | row[]
   | combinedRow[]
@@ -41,6 +49,7 @@ export interface position {
 
 export interface SideBarProps {
   stateManager: stateManager;
+  width: string;
 }
 
 export interface FilterOptionsProps {
@@ -67,6 +76,7 @@ export interface SelectedDetailRowProps {
 
 export interface MapChartProps {
   stateManager: stateManager;
+  width: string;
 }
 
 export interface ZoomControlProps {
@@ -92,6 +102,7 @@ export interface state {
   searchBarContent: string;
   useMarkerVisibility: boolean;
   useSearchBar: boolean;
+  inFullMode: boolean;
 }
 
 export interface action {


### PR DESCRIPTION
Resolves [#7861](https://github.com/cBioPortal/cbioportal/issues/7861).

### Changes made:
- Added logic to render a small map and disable the sidebar, zoom controls, zooming/panning if the url query string has `small` defined
- Changed body background to white

### Before:
#### The `bar=2` is just there to demonstrate that multiple queries can be added, but only `small=X` is considered for now
![image](https://user-images.githubusercontent.com/33106214/92284775-c8effa00-eed0-11ea-9e35-a39f96455ff1.png)
![image](https://user-images.githubusercontent.com/33106214/92284918-15d3d080-eed1-11ea-98f7-7038fb94fd9a.png)

### After:
![image](https://user-images.githubusercontent.com/33106214/92284793-d311f880-eed0-11ea-9bef-c663b737da08.png)
![image](https://user-images.githubusercontent.com/33106214/92284903-0ce2ff00-eed1-11ea-84ff-3dc7be55435c.png)

