### PR TITLE
Revise features based on code review

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -93,7 +93,7 @@ def is_successful(row, keys):
     try:
         successful = row[i] != 'Not yet' and row[j] == 'Yes'
     except IndexError:
-        successful = false
+        successful = False
     finally:
         return successful
 

--- a/src/components/FilterOptions.tsx
+++ b/src/components/FilterOptions.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import * as EventHandlers from "../utils/EventHandlers";
 import * as Types from "../utils/Types";
 
-const FilterOptions = (props: Types.FilterOptionsProps) => {
+const FilterOptions = (props: Types.FilterOptionsProps): JSX.Element => {
   const [state] = props.stateManager;
   return (
     <div className="filter-options">
@@ -22,7 +22,7 @@ const FilterOptions = (props: Types.FilterOptionsProps) => {
       <form className="visibility">
         <input
           type="checkbox"
-          onClick={EventHandlers.handleVisibilityToggle(props.stateManager)}
+          onChange={EventHandlers.handleVisibilityToggle(props.stateManager)}
           checked={state.useMarkerVisibility}
         />
         <label>Filter table by visibility</label>

--- a/src/components/OrphanTableRows.tsx
+++ b/src/components/OrphanTableRows.tsx
@@ -1,42 +1,40 @@
 import React from "react";
-import * as Types from "./../utils/Types";
-import * as Renderers from "../utils/Renderers";
 import * as EventHandlers from "../utils/EventHandlers";
+import * as Renderers from "../utils/Renderers";
 import * as StateUpdaters from "../utils/StateUpdaters";
+import * as Types from "./../utils/Types";
 
 const OrphanTableRows = (props: Types.OrphanTableRowsProps): JSX.Element => {
   const [state, dispatch] = props.stateManager;
-  const rows = props.givenCombinedRow.rows;
-  const combinedRowColor = Renderers.getTableRowColor(
-    props.givenCombinedRow,
-    state.currentCombinedRow,
-    props.givenIndex
-  );
-  const markerIdentifier = StateUpdaters.getMarkerIdentifier(
-    props.givenCombinedRow.index
-  );
+  const givenRow = props.givenCombinedRow;
+  const currentRows = state.currentCombinedRows;
+  const markerIdentifier = StateUpdaters.getMarkerIdentifier(givenRow.index);
+  const highlightValidRow = Renderers.getHighlightClass(givenRow, currentRows);
 
   /* React.Fragment allows for the return of orphan sibling elements without 
   adding an extra parent element to the DOM. The table rows need to be orphans 
   here, or else the encompassing tbody will have an illegal structure. */
   return (
     <React.Fragment>
-      {rows.map((row) => (
-        <tr
-          key={row.index}
-          onClick={EventHandlers.handleMarkerOnClick(
-            dispatch,
-            props.givenCombinedRow
-          )}
-          style={{ background: combinedRowColor }}
-          className={markerIdentifier}
-        >
-          {props.keys.map((key, index) => {
-            const keyIsValid = key in row;
-            return keyIsValid && <td key={index}>{row[key]}</td>;
-          })}
-        </tr>
-      ))}
+      {givenRow.rows.map((row) => {
+        const shouldHighlight = Renderers.handleHighlight(
+          state.currentRow,
+          row
+        );
+        const markerHighlight = highlightValidRow(shouldHighlight);
+        return (
+          <tr
+            key={row.index}
+            onClick={EventHandlers.handleMarkerOnClick(dispatch, givenRow, row)}
+            className={`${markerIdentifier} ${markerHighlight}`}
+          >
+            {props.keys.map((key, index) => {
+              const keyIsValid = key in row;
+              return keyIsValid && <td key={index}>{row[key]}</td>;
+            })}
+          </tr>
+        );
+      })}
     </React.Fragment>
   );
 };

--- a/src/components/RowMarker.tsx
+++ b/src/components/RowMarker.tsx
@@ -1,40 +1,41 @@
 import React from "react";
 import PlaceIcon from "./PlaceIcon";
 import { Marker } from "react-simple-maps";
-import {
-  getCombinedName,
-  displayOnLargeZoom,
-  handleMarkerTransform,
-  getMapMarkerColor,
-  createMarkerText,
-} from "../utils/Renderers";
-import {
-  handleMarkerOnClick,
-  handleMarkerOnMouse,
-} from "../utils/EventHandlers";
-import { getMarkerIdentifier } from "../utils/StateUpdaters";
+import * as Config from "../utils/Config";
+import * as EventHandlers from "../utils/EventHandlers";
+import * as Renderers from "../utils/Renderers";
+import * as StateUpdaters from "../utils/StateUpdaters";
 import * as Types from "../utils/Types";
 
 const RowMarker = (props: Types.RowMarkerProps): JSX.Element => {
   const [state, dispatch] = props.stateManager;
   const currentZoom = state.mousePosition.zoom;
   const givenRow = props.givenCombinedRow;
-  const currentRow = state.currentCombinedRow;
-  const combinedName = getCombinedName(givenRow);
-  const zoomedInEnoughToDisplay = displayOnLargeZoom(currentZoom);
-  const mapMarkerTransform = handleMarkerTransform(currentZoom);
-  const mapMarkerColor = getMapMarkerColor(givenRow, currentRow);
+  const currentRows = state.currentCombinedRows;
+  const combinedName = Renderers.getCombinedName(givenRow);
+  const zoomedInEnoughToDisplay = Renderers.displayOnLargeZoom(currentZoom);
+  const mapMarkerTransform = Renderers.handleMarkerTransform(currentZoom);
+  const mapMarkerColor = Renderers.getMapMarkerColor(givenRow, currentRows);
 
   return (
     <Marker
-      onClick={handleMarkerOnClick(dispatch, givenRow)}
+      onClick={EventHandlers.handleMarkerOnClick(
+        dispatch,
+        givenRow,
+        Config.defaultRow
+      )}
       coordinates={givenRow.averageCoordinates}
-      onMouseEnter={handleMarkerOnMouse(dispatch, combinedName)}
-      onMouseLeave={handleMarkerOnMouse(dispatch)}
-      id={getMarkerIdentifier(givenRow.index)}
+      onMouseEnter={EventHandlers.handleMarkerOnMouse(dispatch, combinedName)}
+      onMouseLeave={EventHandlers.handleMarkerOnMouse(dispatch)}
+      id={StateUpdaters.getMarkerIdentifier(givenRow.index)}
     >
       <PlaceIcon transform={mapMarkerTransform} markerColor={mapMarkerColor} />
-      {zoomedInEnoughToDisplay && createMarkerText(combinedName, currentZoom)}
+      {zoomedInEnoughToDisplay &&
+        Renderers.createMarkerText(
+          combinedName,
+          givenRow.rows.length,
+          currentZoom
+        )}
     </Marker>
   );
 };

--- a/src/components/SelectedDetail.tsx
+++ b/src/components/SelectedDetail.tsx
@@ -1,18 +1,16 @@
 import React from "react";
 import * as Config from "../utils/Config";
 import * as Types from "../utils/Types";
-import { getDefaultRowColor } from "../utils/Renderers";
 
 const SelectedDetail = (props: Types.SelectedDetailProps): JSX.Element => {
-  const defaultRowColor = getDefaultRowColor(props.orderedIndex);
   return (
     <thead>
       {Config.markerDetailMap.map((markerDetail, index) => {
         const { key, header, getRowPropContent } = markerDetail;
         const rowProp = props.row[key];
         return (
-          <tr key={index} style={{ background: defaultRowColor }}>
-            <th style={{ background: Config.tableHeaderColor }}>{header}</th>
+          <tr key={index}>
+            <th>{header}</th>
             <td>{getRowPropContent(rowProp)}</td>
           </tr>
         );

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -20,7 +20,7 @@ const SideBar = (props: Types.SideBarProps): JSX.Element => {
       </div>
       <FilterOptions stateManager={props.stateManager} />
       <h1>Selected waypoint details</h1>
-      <div className="tableFixHead waypoint-details">
+      <div className="tableFixHead" id="waypoint-details">
         <table>{createWaypointDetails(props.stateManager)}</table>
       </div>
     </div>

--- a/src/components/ZoomControls.tsx
+++ b/src/components/ZoomControls.tsx
@@ -1,16 +1,13 @@
 import React from "react";
-import { displayDebuggingFeatures } from "./../utils/Renderers";
 import { handleZoomIn, handleZoomOut } from "./../utils/EventHandlers";
 import { ReactComponent as ZoomIn } from "./zoom-in.svg";
 import { ReactComponent as ZoomOut } from "./zoom-out.svg";
 import * as Config from "./../utils/Config";
 import * as Types from "./../utils/Types";
 
-const ZoomControls = (props: Types.ZoomControlProps) => {
-  const [state] = props.stateManager;
+const ZoomControls = (props: Types.ZoomControlProps): JSX.Element => {
   return (
     <div className="controls-wrapper">
-      {displayDebuggingFeatures(true, state.mousePosition)}
       <div className="controls">
         <button
           onClick={handleZoomIn(props.stateManager)}

--- a/src/index.css
+++ b/src/index.css
@@ -72,15 +72,6 @@ svg {
   margin-right: 0.25rem;
 }
 
-.tableFixHead {
-  overflow-y: auto;
-  max-height: 18em;
-}
-#waypoints thead th {
-  position: sticky;
-  top: 0;
-}
-
 table {
   border-collapse: collapse;
   width: 100%;
@@ -89,8 +80,38 @@ th,
 td {
   padding: 8px 16px;
 }
+
+.tableFixHead {
+  overflow-y: auto;
+  max-height: 18em;
+}
+
 .tableFixHead:first-of-type {
   margin-bottom: 0.67em;
+}
+
+#waypoints thead th {
+  position: sticky;
+  top: 0;
+}
+
+#waypoints-head th,
+#waypoint-details thead th {
+  background: #dcdcdc;
+}
+
+#waypoints tr:nth-child(odd),
+#waypoint-details thead:nth-child(odd) td {
+  background: #ededed;
+}
+
+#waypoints tr:nth-child(even),
+#waypoint-details thead:nth-child(even) td {
+  background: #f6f6f6;
+}
+
+.highlighted {
+  background: #c3e3fb !important;
 }
 
 /* The thick country border that gets displayed when clicking on a country is 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,41 +12,13 @@ const App = (): JSX.Element => {
   const stateManager = useReducer(StateUpdaters.reducer, Config.defaultState);
   const [state, dispatch] = stateManager;
 
-  // Promise to get markers for served build
-  useEffect(() => {
-    const fetchMarkers = async () => {
-      const response = await fetch("/static/waypoints.json");
-      const markers = await response.json();
-      dispatch({ type: "setRows", value: markers });
-    };
-    fetchMarkers();
-  }, [dispatch]);
-
-  // Only rerenders when current combinedRows differs from previous.
-  useEffect(() => {
-    dispatch({
-      type: "updateCombinedRows",
-      value: StateUpdaters.getUpdatedCombinedRowsByZoom(
-        state.rows,
-        state.combinedRows,
-        state.mousePosition.zoom
-      ),
-    });
-  }, [
-    dispatch,
+  // Update markers from spreadsheet and render via zoom level
+  useEffect(StateUpdaters.getJsonMarkers(dispatch), []);
+  useEffect(StateUpdaters.updateAllAndCurrentCombinedRows(stateManager), [
     state.rows,
-    state.combinedRows,
-    state.mousePosition.zoom,
-    state.mousePosition.coordinates,
+    state.mousePosition,
+    state.useMarkerVisibility,
   ]);
-
-  // Display configuration for cBioPortal sidebar vs. full standalone page
-  useEffect(() => {
-    dispatch({
-      type: "setInFullMode",
-      value: StateUpdaters.checkInFullMode(),
-    });
-  }, [dispatch]);
 
   const fullModeRender = (): JSX.Element => {
     Renderers.setRootElementWidth(Config.fullWidth);

--- a/src/utils/Config.tsx
+++ b/src/utils/Config.tsx
@@ -1,5 +1,6 @@
 import { Point } from "react-simple-maps";
 import * as Types from "./Types";
+import * as StateUpdaters from "./StateUpdaters";
 
 /**
  * Constants
@@ -13,17 +14,18 @@ export const baseStrokeThickness = 1;
 export const baseTranslateOffset = 12;
 export const baseZoomThreshold = 16;
 export const defaultMarkerColor = "#3786C2";
-export const evenRowColor = "#ededed";
 export const highlightedMarkerColor = "#8bc5f1";
-export const highlightedRowColor = "#c3e3fb";
 export const maxZoom = 128;
 export const minZoom = 1;
-export const oddRowColor = "#f6f6f6";
-export const tableHeaderColor = "#dcdcdc";
 export const zoomMultiplier = 2;
+export const zoomForFullName = 64;
 export const urlQuery: RegExp = /\?/i;
 export const fullWidth = "unset";
 export const smallWidth = "342px";
+export const mapContainerName = "container";
+export const rootContainerName = "root";
+export const enableHighlight = "highlighted";
+export const disableHighlight = "";
 
 /**
  * World map JSON Url:
@@ -38,40 +40,50 @@ export const geoUrl =
 /**
  * Default values
  */
-export const defaultCoordinates: Point = [0, 0];
-export const defaultRows: Types.row[] = [];
-export const defaultIndex: number = -1;
-export const defaultVisibility = undefined;
-export const defaultCombinedRows: Types.combinedRow[] = [];
+const defaultCoordinates: Point = [0, 0];
+const defaultRows: Types.Row[] = [];
+const defaultIndex: number = -1;
+const defaultVisibility = undefined;
+export const defaultCombinedRows: Types.CombinedRow[] = [];
 export const defaultTooltipContent: string = "";
-export const defaultCombinedRow: Types.combinedRow = {
+export const defaultCombinedRow: Types.CombinedRow = {
   averageCoordinates: defaultCoordinates,
   rows: defaultRows,
   index: defaultIndex,
   isMarkerVisible: defaultVisibility,
 };
-export const defaultMousePosition: Types.position = {
+const defaultMousePosition: Types.Position = {
   coordinates: defaultCoordinates,
   zoom: minZoom,
 };
 export const defaultSearchBarContent: string = "";
-export const defaultToggle: boolean = false;
-export const defaultState: Types.state = {
+const defaultToggle: boolean = false;
+const defaultMode: boolean = StateUpdaters.checkInFullMode();
+export const defaultRow: Types.Row = {
+  institution: "",
+  category: "",
+  lab: "",
+  address: "",
+  coordinates: [0, 0],
+  index: -1,
+};
+export const defaultState: Types.State = {
   rows: defaultRows,
-  combinedRows: defaultCombinedRows,
+  allCombinedRows: defaultCombinedRows,
   tooltipContent: defaultTooltipContent,
-  currentCombinedRow: defaultCombinedRow,
+  currentCombinedRows: defaultCombinedRows,
   mousePosition: defaultMousePosition,
   searchBarContent: defaultSearchBarContent,
   useMarkerVisibility: defaultToggle,
   useSearchBar: defaultToggle,
-  inFullMode: defaultToggle,
+  inFullMode: defaultMode,
+  currentRow: defaultRow,
 };
 
 /**
  * Configuration for mapping JSON keys to table row header and data cells.
  */
-export const markerDetailMap: Types.markerDetail[] = [
+export const markerDetailMap: Types.MarkerDetail[] = [
   {
     key: "institution",
     header: "Institution or Company Name",
@@ -109,7 +121,6 @@ export const tableHeaderKeys = ["institution", "lab", "address"];
 export const componentIds: Types.componentToIdentifier = {
   Marker: (index: number) => `marker-${index}`,
 };
-export const mapContainerName = "container";
 
 // Configuration for rendering MapChart.
 export const fullModeDimensions = {

--- a/src/utils/Types.tsx
+++ b/src/utils/Types.tsx
@@ -1,9 +1,7 @@
 import { Point } from "react-simple-maps";
 
 export type RowProp = string | Point | number;
-export type CombinedProp = Point | row[] | number | Visibility;
-export type Dispatch = React.Dispatch<action>;
-export type ZoomHandler = (zoom: number) => void;
+export type CombinedProp = Point | Row[] | number | Visibility;
 export type Visibility = boolean | undefined;
 export type Parameters = {
   [key: string]: string | undefined;
@@ -14,15 +12,15 @@ export type Dimensions = {
   scale: number;
 };
 export type StateProp =
-  | row[]
-  | combinedRow[]
+  | Row[]
+  | CombinedRow[]
   | string
-  | combinedRow
-  | position
+  | Row
+  | Position
   | number
   | boolean;
 
-export interface row {
+export type Row = {
   institution: string;
   category: string;
   lab: string;
@@ -31,94 +29,101 @@ export interface row {
   index: number;
 
   [key: string]: RowProp;
-}
+};
 
-export interface combinedRow {
+export type CombinedRow = {
   index: number;
   averageCoordinates: Point;
-  rows: row[];
+  rows: Row[];
   isMarkerVisible: Visibility;
 
   [key: string]: CombinedProp;
-}
+};
 
-export interface position {
+export type Position = {
   coordinates: Point;
   zoom: number;
-}
+};
+
+export type Action = {
+  type: string;
+  value: StateProp;
+};
+export type State = {
+  rows: Row[];
+  allCombinedRows: CombinedRow[];
+  tooltipContent: string;
+  currentCombinedRows: CombinedRow[];
+  mousePosition: Position;
+  searchBarContent: string;
+  useMarkerVisibility: boolean;
+  useSearchBar: boolean;
+  inFullMode: boolean;
+  currentRow: Row;
+};
+export type Dispatch = React.Dispatch<Action>;
+export type StateManager = [State, Dispatch];
+
+export type MarkerDetail = {
+  key: string;
+  header: string;
+  getRowPropContent: (value: any) => string;
+};
+
+export type FilterPredicate = (combinedRow: CombinedRow) => boolean;
+
+export type DisplayedPair = { name: string; fontStyle: string };
+
+export type Limits = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
 
 export interface SideBarProps {
-  stateManager: stateManager;
+  stateManager: StateManager;
   width: string;
 }
 
 export interface FilterOptionsProps {
-  stateManager: stateManager;
+  stateManager: StateManager;
 }
 
 export interface OrphanTableRowsProps {
   keys: string[];
-  stateManager: stateManager;
-  givenCombinedRow: combinedRow;
-  givenIndex: number;
+  stateManager: StateManager;
+  givenCombinedRow: CombinedRow;
 }
 
 export interface SelectedDetailProps {
-  row: row;
+  row: Row;
   orderedIndex: number;
 }
 
 export interface SelectedDetailRowProps {
-  markerDetail: markerDetail;
+  markerDetail: MarkerDetail;
   defaultRowColor: string;
-  row: row;
+  row: Row;
 }
 
 export interface MapChartProps {
-  stateManager: stateManager;
+  stateManager: StateManager;
   width: string;
 }
 
 export interface ZoomControlProps {
-  stateManager: stateManager;
+  stateManager: StateManager;
 }
 
 export interface RowMarkerProps {
-  givenCombinedRow: combinedRow;
-  stateManager: stateManager;
+  givenCombinedRow: CombinedRow;
+  stateManager: StateManager;
 }
 
 export interface PlaceIconProps {
   transform: string;
   markerColor: string;
-}
-
-export interface state {
-  rows: row[];
-  combinedRows: combinedRow[];
-  tooltipContent: string;
-  currentCombinedRow: combinedRow;
-  mousePosition: position;
-  searchBarContent: string;
-  useMarkerVisibility: boolean;
-  useSearchBar: boolean;
-  inFullMode: boolean;
-}
-
-export interface action {
-  type: string;
-  value: StateProp;
-}
-
-export interface stateManager extends Array<state | Dispatch> {
-  0: state;
-  1: Dispatch;
-}
-
-export interface markerDetail {
-  key: string;
-  header: string;
-  getRowPropContent: (value: any) => string;
 }
 
 export interface componentToIdentifier {


### PR DESCRIPTION
Will resolve [#7866](https://github.com/cBioPortal/cbioportal/issues/7866)

### Changes made so far:
#### Display "X installations" as marker text for markers with 2+ installations
##### Before
![old_truncated_name](https://user-images.githubusercontent.com/33106214/92985528-7b036500-f481-11ea-815e-b5582e6046e6.gif)

##### After
![new_truncated_name](https://user-images.githubusercontent.com/33106214/92985508-3f689b00-f481-11ea-81e1-a5c9f53f8fe3.gif)

#### Resolved "unmounted component" and "failed prop type check" errors
- Changed checkbox `onClick` to `onChange`
- Initialized `state.inFullMode` with real default value instead of updating it with a `dispatch` call inside a `useEffect`

#### Have marker/row highlight and details persist upon zooming in/out for markers that split/merge
##### Before
![old_zoom_not_persist_highlight_details](https://user-images.githubusercontent.com/33106214/92985470-bfdacc00-f480-11ea-9198-0882a4256abd.gif)
##### After (see Bugs section)
![zoom_persists_highlight_details](https://user-images.githubusercontent.com/33106214/92985254-f7e10f80-f47e-11ea-9ee3-12bcfe06f591.gif)

#### Odd and even table rows are now colored dark and light gray
##### Before
![old_table_rows_coloring](https://user-images.githubusercontent.com/33106214/92985451-928e1e00-f480-11ea-889b-8d689d329918.gif)
##### After
![new_table_rows_coloring](https://user-images.githubusercontent.com/33106214/92985452-94f07800-f480-11ea-9afc-8e4173137c30.gif)

#### Displayed markers are correctly marked as visible and undisplayed ones as not visible
##### Before
![incorrect_visibility](https://user-images.githubusercontent.com/33106214/93121622-2800fc00-f693-11ea-935f-d7f6e0f6078d.gif)

##### After
![correct_visibility](https://user-images.githubusercontent.com/33106214/93121531-f8ea8a80-f692-11ea-82f9-3dd842b9e985.gif)

### Clicking on a table row only highlights/displays details of/scrolls to that particular row.
- See the below post for more details.

### Bug(s)
Sometimes table scroll does not properly scroll to the earliest entry of the currentCombinedRow (handles the Marker, table row, details). 