### PR TITLE
Refactor to use cBioPortal styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "@types/react-simple-maps": "^1.0.3",
-    "@types/react-tooltip": "^4.2.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
@@ -20,7 +19,7 @@
     "typescript": "~3.7.2"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3006 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/components/MapChart.tsx
+++ b/src/components/MapChart.tsx
@@ -13,7 +13,7 @@ const MapChart = (props: Types.MapChartProps): JSX.Element => {
   const fullModeRender = (): JSX.Element => {
     return (
       <div className="mapchart" style={{ width: props.width }}>
-        <ZoomControls stateManager={props.stateManager} />
+        <ZoomControls stateManager={props.stateManager} width={props.width} />
         <ComposableMap
           id={Config.mapContainerName}
           width={dimensions.width}

--- a/src/components/RowMarker.tsx
+++ b/src/components/RowMarker.tsx
@@ -25,8 +25,6 @@ const RowMarker = (props: Types.RowMarkerProps): JSX.Element => {
         Config.defaultRow
       )}
       coordinates={givenRow.averageCoordinates}
-      onMouseEnter={EventHandlers.handleMarkerOnMouse(dispatch, combinedName)}
-      onMouseLeave={EventHandlers.handleMarkerOnMouse(dispatch)}
       id={StateUpdaters.getMarkerIdentifier(givenRow.index)}
     >
       <PlaceIcon transform={mapMarkerTransform} markerColor={mapMarkerColor} />

--- a/src/components/SelectedDetail.tsx
+++ b/src/components/SelectedDetail.tsx
@@ -4,7 +4,7 @@ import * as Types from "../utils/Types";
 
 const SelectedDetail = (props: Types.SelectedDetailProps): JSX.Element => {
   return (
-    <thead>
+    <React.Fragment>
       {Config.markerDetailMap.map((markerDetail, index) => {
         const { key, header, getRowPropContent } = markerDetail;
         const rowProp = props.row[key];
@@ -15,7 +15,7 @@ const SelectedDetail = (props: Types.SelectedDetailProps): JSX.Element => {
           </tr>
         );
       })}
-    </thead>
+    </React.Fragment>
   );
 };
 

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -1,27 +1,30 @@
 import React from "react";
 import * as Config from "../utils/Config";
+import * as Renderers from "../utils/Renderers";
 import * as Types from "../utils/Types";
-import {
-  createWaypointsTableHead,
-  createWaypointsTableBody,
-  createWaypointDetails,
-} from "../utils/Renderers";
 import FilterOptions from "./FilterOptions";
 
 const SideBar = (props: Types.SideBarProps): JSX.Element => {
   return (
-    <div className="left" style={{ width: props.width }}>
-      <h1>Waypoints</h1>
-      <div className="tableFixHead" id="waypoints">
-        <table>
-          {createWaypointsTableHead(Config.tableHeaderKeys)}
-          {createWaypointsTableBody(props.stateManager, Config.tableHeaderKeys)}
-        </table>
+    <div className="sidebar" style={{ width: props.width }}>
+      <div id="waypoints">
+        <h1>Waypoints</h1>
+        <FilterOptions stateManager={props.stateManager} />
+        <div className="tableFixHead">
+          <table>
+            {Renderers.createWaypointsTableHead(Config.tableHeaderKeys)}
+            {Renderers.createWaypointsTableBody(
+              props.stateManager,
+              Config.tableHeaderKeys
+            )}
+          </table>
+        </div>
       </div>
-      <FilterOptions stateManager={props.stateManager} />
-      <h1>Selected waypoint details</h1>
-      <div className="tableFixHead" id="waypoint-details">
-        <table>{createWaypointDetails(props.stateManager)}</table>
+      <div id="waypoint-details">
+        <h1>Selected waypoint details</h1>
+        <div className="tableFixHead">
+          <table>{Renderers.createWaypointDetails(props.stateManager)}</table>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ZoomControls.tsx
+++ b/src/components/ZoomControls.tsx
@@ -1,27 +1,18 @@
 import React from "react";
-import { handleZoomIn, handleZoomOut } from "./../utils/EventHandlers";
+import * as EventHandlers from "./../utils/EventHandlers";
 import { ReactComponent as ZoomIn } from "./zoom-in.svg";
 import { ReactComponent as ZoomOut } from "./zoom-out.svg";
-import * as Config from "./../utils/Config";
 import * as Types from "./../utils/Types";
 
 const ZoomControls = (props: Types.ZoomControlProps): JSX.Element => {
   return (
-    <div className="controls-wrapper">
-      <div className="controls">
-        <button
-          onClick={handleZoomIn(props.stateManager)}
-          style={{ background: Config.defaultMarkerColor }}
-        >
-          <ZoomIn />
-        </button>
-        <button
-          onClick={handleZoomOut(props.stateManager)}
-          style={{ background: Config.defaultMarkerColor }}
-        >
-          <ZoomOut />
-        </button>
-      </div>
+    <div className="controls" style={{ width: props.width }}>
+      <button onClick={EventHandlers.handleZoomIn(props.stateManager)}>
+        <ZoomIn />
+      </button>
+      <button onClick={EventHandlers.handleZoomOut(props.stateManager)}>
+        <ZoomOut />
+      </button>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,64 +1,54 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
-}
-
-html {
-  font-family: system-ui, sans-serif;
-  font-size: 1.25rem;
-}
-
-svg {
-  display: inline-block;
-  vertical-align: middle;
+  padding: 0;
+  overflow-y: scroll;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.428571429;
+  color: #333333;
 }
 
 #wrapper {
   display: flex;
-  flex-direction: row;
+  align-items: center;
+  justify-content: center;
 }
 
-.left {
-  background-color: #f9f9f9;
+.sidebar {
+  background-color: #f5f5f5;
   align-self: stretch;
+  padding: 5px;
 }
 
-.left h1 {
+.sidebar h1 {
   font-size: 24px;
   color: #3786c2;
-  font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 500;
   line-height: 1.1;
-  margin: 0.67em 0;
+  margin: 0 0 0.67em 0;
   box-sizing: border-box;
-  margin-left: 20px;
+  text-align: center;
 }
 
 .mapchart {
   background: #fff;
+  cursor: grab;
 }
 
-.controls-wrapper {
-  width: 75%;
-  position: fixed;
+.mapchart:active,
+.mapchart:focus-within {
+  cursor: grabbing;
 }
 
 .controls {
+  margin-top: 1.25rem;
+  position: fixed;
   display: flex;
-  margin: 1.25rem 0 0 0;
   justify-content: center;
 }
 
-.controls > button {
+.controls button {
   justify-content: center;
   align-items: center;
   padding: 0;
@@ -66,104 +56,163 @@ svg {
   width: 2rem;
   border-radius: 100%;
   border: 0;
+  background: #3786c2;
+}
+
+.controls button:hover {
+  background: #8bc5f1;
+  cursor: default;
 }
 
 .controls > button:first-child {
   margin-right: 0.25rem;
 }
 
-table {
-  border-collapse: collapse;
-  width: 100%;
-}
-th,
-td {
-  padding: 8px 16px;
+.rsm-marker:hover,
+.rsm-marker:active {
+  cursor: default;
 }
 
-.tableFixHead {
-  overflow-y: auto;
-  max-height: 18em;
+/* Outline width can't change upon zoom, so hide it. */
+.rsm-geography,
+.search input,
+.controls button {
+  outline: 0;
 }
 
-.tableFixHead:first-of-type {
-  margin-bottom: 0.67em;
+.filter-options {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.search {
+  display: flex;
+  flex-grow: 1;
+  margin-right: 5px;
+}
+
+.search input {
+  display: block;
+  color: #555555;
+  background-image: none;
+  border: 1px solid #ddd;
+  font-size: 12px;
+  padding: 5px 10px;
+  line-height: 1.5;
+  transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+}
+
+.search input[type="text"] {
+  background: #fff;
+  border-radius: 3px;
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  flex-grow: 1;
+}
+
+.search input[type="text"]:focus {
+  border-color: #66afe9;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075),
+    0 0 8px rgba(102, 175, 233, 0.6);
+}
+
+.search input[type="button"] {
+  background: #ddd;
+  border-radius: 3px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  cursor: default;
+}
+
+.search input[type="button"]:hover {
+  background: #ccc;
+  border: 1px solid #ccc;
+}
+
+.visibility {
+  display: flex;
+  justify-content: center;
+}
+
+#waypoints,
+#waypoint-details {
+  background: #fff;
+  padding: 5px;
+  border-radius: 5px;
+}
+
+#waypoints {
+  margin-bottom: 20px;
 }
 
 #waypoints thead th {
+  box-shadow: 0 2px 0 #ccc;
   position: sticky;
   top: 0;
+  text-transform: capitalize;
+}
+
+#waypoints tbody td,
+#waypoint-details td {
+  padding: 3px 10px;
+  border-top: none;
+}
+
+#waypoints tr,
+.search input[type="button"],
+.controls button {
+  transition: background-color ease-in-out 0.15s;
 }
 
 #waypoints-head th,
-#waypoint-details thead th {
-  background: #dcdcdc;
+#waypoint-details th {
+  vertical-align: top;
+  line-height: 1.1;
+  padding: 8px;
+  text-align: left;
+  background: #fff;
 }
 
 #waypoints tr:nth-child(odd),
-#waypoint-details thead:nth-child(odd) td {
-  background: #ededed;
+#waypoint-details tr:nth-child(odd) td {
+  background: #f9f9f9;
 }
 
 #waypoints tr:nth-child(even),
-#waypoint-details thead:nth-child(even) td {
-  background: #f6f6f6;
+#waypoint-details tr:nth-child(even) td {
+  background: #fff;
+}
+
+#waypoint-details tr {
+  display: flex;
+}
+
+#waypoint-details tr:nth-child(5n) {
+  border-bottom: 1px solid #ccc;
+}
+
+#waypoint-details th {
+  flex: 2;
+}
+
+#waypoint-details td {
+  flex-grow: 1;
+  flex: 3;
 }
 
 .highlighted {
   background: #c3e3fb !important;
 }
 
-/* The thick country border that gets displayed when clicking on a country is 
-a bit annoying to look at. It would be nice to have its border scale by zoom, 
-just like the rest of the svg elements. I've tried to modify the width via 
-CSS just to see how the border width works, but it looks like setting the 
-width to any nonnegative number still displays the border with the same 
-visible width. e.g. 500px or 5px or 1px still shows the same thick border. But 
-changing it to 0px makes the border totally disappear, so I know the 
-outline-width property still works! How confusing. */
-.rsm-geography:focus {
-  /* outline: -webkit-focus-ring-color auto 5px; */
-  /* outline-color: -webkit-focus-ring-color; */
-  /* outline-style: auto; */
-  outline-width: 0px;
+.tableFixHead {
+  overflow-y: auto;
+  max-height: 25em;
 }
 
-.filter-options {
-  float: left;
-  margin-bottom: 1em;
-  margin-left: 20px;
-}
-
-.search {
-  float: left;
-}
-
-.search input[type="text"] {
-  border: none;
-  float: left;
-  font-size: 17px;
-  margin-top: 8px;
-  min-width: 250px;
-  padding: 6px;
-}
-
-.search input[type="button"] {
-  border: none;
-  cursor: pointer;
-  background: #ddd;
-  float: left;
-  font-size: 17px;
-  margin-top: 8px;
-  margin-right: 8px;
-  padding: 6px;
-}
-
-.search button:hover {
-  background: #ccc;
-}
-
-.visibility {
-  float: left;
-  margin-top: 8px;
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  width: 100%;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useReducer } from "react";
 import ReactDOM from "react-dom";
-import ReactTooltip from "react-tooltip";
 import MapChart from "./components/MapChart";
 import SideBar from "./components/SideBar";
 import * as Config from "./utils/Config";
-import * as Renderers from "./utils/Renderers";
 import * as StateUpdaters from "./utils/StateUpdaters";
 import "./index.css";
 
@@ -21,18 +19,15 @@ const App = (): JSX.Element => {
   ]);
 
   const fullModeRender = (): JSX.Element => {
-    Renderers.setRootElementWidth(Config.fullWidth);
     return (
       <div id="wrapper">
         <SideBar stateManager={stateManager} width="30%" />
         <MapChart stateManager={stateManager} width="70%" />
-        <ReactTooltip>{state.tooltipContent}</ReactTooltip>
       </div>
     );
   };
 
   const smallModeRender = (): JSX.Element => {
-    Renderers.setRootElementWidth(Config.smallWidth);
     return (
       <div id="wrapper">
         <MapChart stateManager={stateManager} width="100%" />
@@ -43,5 +38,5 @@ const App = (): JSX.Element => {
   return state.inFullMode ? fullModeRender() : smallModeRender();
 };
 
-const rootElement = document.getElementById("root");
+const rootElement = document.getElementById(Config.rootContainerName);
 ReactDOM.render(<App />, rootElement);

--- a/src/utils/Config.tsx
+++ b/src/utils/Config.tsx
@@ -20,10 +20,10 @@ export const minZoom = 1;
 export const zoomMultiplier = 2;
 export const zoomForFullName = 64;
 export const urlQuery: RegExp = /\?/i;
-export const fullWidth = "unset";
-export const smallWidth = "342px";
 export const mapContainerName = "container";
 export const rootContainerName = "root";
+export const scrollableTableName = "tableFixHead";
+export const waypointsHeadName = "waypoints-head";
 export const enableHighlight = "highlighted";
 export const disableHighlight = "";
 
@@ -45,7 +45,6 @@ const defaultRows: Types.Row[] = [];
 const defaultIndex: number = -1;
 const defaultVisibility = undefined;
 export const defaultCombinedRows: Types.CombinedRow[] = [];
-export const defaultTooltipContent: string = "";
 export const defaultCombinedRow: Types.CombinedRow = {
   averageCoordinates: defaultCoordinates,
   rows: defaultRows,
@@ -70,7 +69,6 @@ export const defaultRow: Types.Row = {
 export const defaultState: Types.State = {
   rows: defaultRows,
   allCombinedRows: defaultCombinedRows,
-  tooltipContent: defaultTooltipContent,
   currentCombinedRows: defaultCombinedRows,
   mousePosition: defaultMousePosition,
   searchBarContent: defaultSearchBarContent,

--- a/src/utils/EventHandlers.tsx
+++ b/src/utils/EventHandlers.tsx
@@ -59,18 +59,6 @@ export const handleZoomOut = (stateManager: Types.StateManager) => (): void => {
     });
 };
 
-//////////////////
-// RowMarker.tsx
-//////////////////
-
-export const handleMarkerOnMouse = (
-  dispatch: Types.Dispatch,
-  combinedName?: string
-) => (): void => {
-  const newTooltipContent = combinedName || Config.defaultTooltipContent;
-  dispatch({ type: "setTooltipContent", value: newTooltipContent });
-};
-
 ////////////////////////
 // OrphanTableRows.tsx
 ////////////////////////
@@ -98,19 +86,20 @@ export const handleWaypointsTableScrollbar = (
   combinedRowIndex: number,
   rowIndex: number
 ): void => {
-  const waypointsTable = document.getElementById("waypoints");
+  const waypointsTable = document.getElementsByClassName(
+    Config.scrollableTableName
+  )[0];
   const firstRowOffset = getFirstRowOffset(combinedRowIndex, rowIndex);
   const tableHeadHeight = getTableHeadHeight();
   if (!waypointsTable || !firstRowOffset || !tableHeadHeight) {
   } else {
-    const defaultHorizontalPosition = 0;
     const newVerticalPosition = firstRowOffset - tableHeadHeight;
-    waypointsTable.scrollTo(defaultHorizontalPosition, newVerticalPosition);
+    waypointsTable.scrollTo({ top: newVerticalPosition, behavior: "smooth" });
   }
 };
 
 const getTableHeadHeight = (): number | undefined => {
-  const waypointsTableHead = document.getElementById("waypoints-head");
+  const waypointsTableHead = document.getElementById(Config.waypointsHeadName);
   return waypointsTableHead?.offsetHeight;
 };
 

--- a/src/utils/Renderers.tsx
+++ b/src/utils/Renderers.tsx
@@ -229,21 +229,39 @@ export const createMarkerText = (
   numberOfRows: number,
   zoom: number
 ): JSX.Element => {
-  const mapMarkerOffset = handleMarkerOffset(zoom);
-  const mapMarkerFontSize = handleMarkerFontSize(zoom);
+  const offsetFromMarker = handleMarkerOffset(zoom);
+  const nameFontSize = handleMarkerFontSize(zoom);
   const displayedPair = getDisplayedPair(zoom, numberOfRows, combinedName);
   const displayedName = displayedPair.name;
   const displayedStyle = displayedPair.fontStyle;
-
   return (
     <text
       textAnchor="middle"
-      y={mapMarkerOffset}
-      style={{ fontSize: mapMarkerFontSize, fontStyle: displayedStyle }}
+      y={offsetFromMarker}
+      style={{ fontStyle: displayedStyle }}
     >
-      {displayedName}
+      <tspan x="0" style={{ fontSize: nameFontSize }}>
+        {displayedName}
+      </tspan>
+      {displaySubtitle(displayedName, nameFontSize)}
     </text>
   );
+};
+
+const displaySubtitle = (
+  displayedName: string,
+  nameFontSize: number
+): JSX.Element | null => {
+  const showsNumberOfInstallations = displayedName
+    .toLocaleLowerCase()
+    .includes("installations");
+  const subtitleMultiplier = 0.8;
+  const subtitleFontSize = subtitleMultiplier * nameFontSize;
+  return showsNumberOfInstallations ? (
+    <tspan x="0" dy="1.2em" style={{ fontSize: subtitleFontSize }}>
+      Click for details
+    </tspan>
+  ) : null;
 };
 
 const getDisplayedPair = (
@@ -256,7 +274,7 @@ const getDisplayedPair = (
   if (canDisplayFullName) {
     return { name: combinedName, fontStyle: "normal" };
   } else if (existsMoreThanOneRow) {
-    const truncatedName = `${numberOfRows} installations`;
+    const truncatedName = `${numberOfRows} Installations`;
     return { name: truncatedName, fontStyle: "italic" };
   } else {
     const truncatedName = getTruncatedName(zoom, combinedName);
@@ -361,13 +379,13 @@ const createOrphanTableRows = (
 
 export const createWaypointDetails = (
   stateManager: Types.StateManager
-): JSX.Element[] => {
+): JSX.Element => {
   const [state] = stateManager;
   const shouldDisplaySingleRow = state.currentRow !== Config.defaultRow;
   const rows = shouldDisplaySingleRow
     ? [state.currentRow]
     : getFlattenedChildRows(state.currentCombinedRows);
-  return rows.map(createSelectedDetail);
+  return <thead>{rows.map(createSelectedDetail)}</thead>;
 };
 
 export const getFlattenedChildRows = (
@@ -408,15 +426,4 @@ export const handleHighlight = (
 
 export const rowIsDefault = (givenRow: Types.Row): boolean => {
   return givenRow === Config.defaultRow;
-};
-
-//////////////
-// index.tsx
-//////////////
-
-export const setRootElementWidth = (value: string): void => {
-  const rootElement = document.getElementById(Config.rootContainerName);
-  if (!!rootElement) {
-    rootElement.style.width = value;
-  }
 };

--- a/src/utils/Types.tsx
+++ b/src/utils/Types.tsx
@@ -52,7 +52,6 @@ export type Action = {
 export type State = {
   rows: Row[];
   allCombinedRows: CombinedRow[];
-  tooltipContent: string;
   currentCombinedRows: CombinedRow[];
   mousePosition: Position;
   searchBarContent: string;
@@ -114,6 +113,7 @@ export interface MapChartProps {
 
 export interface ZoomControlProps {
   stateManager: StateManager;
+  width: string;
 }
 
 export interface RowMarkerProps {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,13 +1678,6 @@
     "@types/geojson" "*"
     "@types/react" "*"
 
-"@types/react-tooltip@^4.2.4":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@types/react-tooltip/-/react-tooltip-4.2.4.tgz#d0acad2a3061806e10aab91dd26a95a77fd35125"
-  integrity sha512-UzjzmgY/VH3Str6DcAGTLMA1mVVhGOyARNTANExrirtp+JgxhaIOVDxq4TIRmpSi4voLv+w4HA9CC5GvhhCA0A==
-  dependencies:
-    react-tooltip "*"
-
 "@types/react@*", "@types/react@^16.9.0":
   version "16.9.46"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.46.tgz#f0326cd7adceda74148baa9bff6e918632f5069e"
@@ -9102,14 +9095,6 @@ react-simple-maps@^2.1.2:
     d3-zoom "^1.8.3"
     topojson-client "^3.0.0"
 
-react-tooltip@*:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.8.tgz#270858fee46fab73b66de316271aa94145f7446b"
-  integrity sha512-pDWa0/khTAgIfldp95tHgyuYyBhWNlfaU2LF9ubAKxpoqNe15uyf+uLlnhK/Lstb6FU8E8/SL28Wp6oEO9xw3g==
-  dependencies:
-    prop-types "^15.7.2"
-    uuid "^7.0.3"
-
 react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
@@ -10844,11 +10829,6 @@ uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.1"


### PR DESCRIPTION
Resolves [7866](https://github.com/cBioPortal/cbioportal/issues/7866). 
Adopt styles from [this cBioPortal page](https://www.cbioportal.org/results/mutualExclusivity?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=metastatic_solid_tumors_mich_2017%2Cmixed_allen_2018&case_set_id=all&data_priority=1&gene_list=SUGT1P4-STRA6LP-CCDC180%2520BRAF%2520NRAS&geneset_list=%20&profileFilter=1&tab_index=tab_visualize).

## Changes made:
### Styles 
- Move filter options above table
- Centered zoom options to Mapchart, ensuring both have same width
- Added gray/blue blur to searchbar, rounded corners
- Added subtitle text under "X Installations" for markers with >1 installations
- Added gray bottom border to waypoints table headers and details
- Adopted fonts, table styling
- Make sidebar background gray
  - This is because a white background would interfere with the white table headers
- Change sidebar padding to 5px
### Miscellaneous
- Got rid of React Tooltip, which was broken
- Refactor code to make it cleaner
- Host local build on port 3006
- Get rid of logic to set height/width of root element (for homepage sidebar iframe)
  - This is because an iframe, whose `src` contains `?small=1`, can be set to a width/height of 300px/200px. So, there's no need to specify the height/width of the rootElement in the installation map App component. 

### Before:
![before_style_changes](https://user-images.githubusercontent.com/33106214/93616911-59cfd680-f9a3-11ea-8379-53b038ed454a.gif)

### After:
![after_style_changes](https://user-images.githubusercontent.com/33106214/93617232-b29f6f00-f9a3-11ea-9a09-1496062ed951.gif)
