### PR TITLE
Modify page styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -22,7 +22,7 @@
 body {
   margin: 0;
   padding: 0;
-  overflow-y: scroll;
+  overflow-y: hidden;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.428571429;
@@ -261,7 +261,7 @@ body {
 
 .tableFixHead {
   overflow-y: auto;
-  max-height: 23em;
+  max-height: 20em;
 }
 
 .tableFixHead p {


### PR DESCRIPTION
Related to [3410](https://github.com/cBioPortal/cbioportal-frontend/pull/3410), [8003](https://github.com/cBioPortal/cbioportal/issues/8003)

### Changes made
- Reduced table heights so overall page height is not too long for cbioportal static page iframe
- Disabled scrolling on body of page

### Before
![image](https://user-images.githubusercontent.com/33106214/97713745-9e688a80-1a96-11eb-841f-d59e42cb443b.png)

### After
![image](https://user-images.githubusercontent.com/33106214/97713675-8a248d80-1a96-11eb-834e-df17a3d157ae.png)
